### PR TITLE
converted  supplied hash password to plain text and removed unused import

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
-use App\Models\User
 
 class UserFactory extends Factory
 {
@@ -19,7 +18,7 @@ class UserFactory extends Factory
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => 'password',
             'remember_token' => Str::random(10),
         ];
     }


### PR DESCRIPTION
### Changes Made

- Have to convert supplied hash password in seeder to plain text because a method to automatically convert pass to hash was already set in the user model
- Removed unused import